### PR TITLE
[WIP] Support ADTs

### DIFF
--- a/examples/ADT.hs
+++ b/examples/ADT.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE TemplateHaskell, QuasiQuotes, ExplicitForAll, ScopedTypeVariables, EmptyCase #-}
+
+module Main where
+
+import Language.Rust.Inline
+import Language.Rust.Inline.TH
+
+import Foreign.Storable
+
+-- Some ADTs
+data Point a = Point a a deriving (Show)
+-- data Maybe ...  {- already defined in 'Data.Maybe'
+-- data Either ... {- already defined in 'Data.Either'
+
+-- Make some 'Storable' instances
+mkStorable [t| forall a. Storable a => Storable (Point a) |]
+mkStorable [t| forall a. Storable a => Storable (Maybe a) |]
+mkStorable [t| forall e a. (Storable e, Storable a) => Storable (Either e a) |]
+
+-- Generate corresponding Rust types
+extendContext (rustTyCtx [t| forall a. Point a |])
+extendContext (rustTyCtx [t| forall a. Maybe a |])
+extendContext (rustTyCtx [t| forall e a. Either e a |])
+
+-- Some Rust machinery
+[rust|
+impl<T> Maybe<T> {
+  pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Maybe<U> {
+    match self {
+      Maybe::Just(x) => Maybe::Just(f(x)),
+      Maybe::Nothing => Maybe::Nothing,
+    }
+  }
+  
+  pub fn and_then<U, F: FnOnce(T) -> Maybe<U>>(self, f: F) -> Maybe<U> {
+    match self {
+      Maybe::Just(x) => f(x),
+      Maybe::Nothing => Maybe::Nothing,
+    }
+  }
+
+  pub fn unwrap_or(self, def: T) -> T {
+    match self {
+      Maybe::Just(x) => x,
+      Maybe::Nothing => def,
+    }
+  }
+}
+
+impl<E,T> Either<E,T> {
+  pub fn right(self) -> Maybe<T> {
+    match self {
+      Either::Right(x) => Maybe::Just(x),
+      Either::Left(_) => Maybe::Nothing,
+    }
+  }
+
+  pub fn and_then<U, F: FnOnce(T) -> Either<E, U>>(self, op: F) -> Either<E, U> {
+    match self {
+      Either::Right(t) => op(t),
+      Either::Left(e) => Either::Left(e),
+    }
+  }
+}
+|]
+
+main = do
+  let m1 = Just 1
+      m2 = Nothing
+      m3 = Just 8
+
+      p1 = Point (Just 1) (Just 8)
+      p2 = Point Nothing (Just 9)
+      p3 = Point (Just 3) Nothing
+
+  print [rust|
+    Maybe<Point<Maybe<i32>>> {
+      let ms = vec![ $(m1: Maybe<i32>), $(m2: Maybe<i32>), $(m3: Maybe<i32>) ];
+      let ps = vec![ $(p1: Point<Maybe<i32>>), $(p2: Point<Maybe<i32>>), $(p3: Point<Maybe<i32>>) ];
+
+      let mut x = 0i32;
+      let mut y = 0i32;
+      for (&m,&p) in ms.iter().zip(ps.iter()) {
+        if let Maybe::Just(multipler) = m {
+          let Point(mx, my) = p;
+          mx.map(|px| x += px);
+          my.map(|py| y += py);
+        }
+      }
+
+      Maybe::Just(Point(Maybe::Just(x), Maybe::Just(y)))
+    }
+  |]
+

--- a/examples/YourNumber.hs
+++ b/examples/YourNumber.hs
@@ -15,7 +15,7 @@ externCrate "rayon" "0.9"
 [rust|
 fn hi_from_rust(n: u16) -> () {
   print!("hi");
-  for i in 2..n {
+  for i in 1..n {
     print!(" hi")
   }
   println!()

--- a/inline-rust.cabal
+++ b/inline-rust.cabal
@@ -27,6 +27,7 @@ library
   default-language:    Haskell2010
 
   exposed-modules:     Language.Rust.Inline
+                       Language.Rust.Inline.TH
   other-modules:       Language.Rust.Inline.Context
                        Language.Rust.Inline.Marshal
                        Language.Rust.Inline.Parser

--- a/inline-rust.cabal
+++ b/inline-rust.cabal
@@ -34,6 +34,7 @@ library
                        Language.Rust.Inline.Internal
                        Language.Rust.Inline.TH.Storable
                        Language.Rust.Inline.TH.Utilities
+                       Language.Rust.Inline.TH.ReprC
 
   other-extensions:    DeriveDataTypeable
                      , CPP

--- a/inline-rust.cabal
+++ b/inline-rust.cabal
@@ -32,7 +32,8 @@ library
                        Language.Rust.Inline.Parser
                        Language.Rust.Inline.Pretty
                        Language.Rust.Inline.Internal
-                       Language.Rust.Inline.Storable.TH
+                       Language.Rust.Inline.TH.Storable
+                       Language.Rust.Inline.TH.Utilities
 
   other-extensions:    DeriveDataTypeable
                      , CPP

--- a/src/Language/Rust/Inline.hs
+++ b/src/Language/Rust/Inline.hs
@@ -74,7 +74,7 @@ import Language.Rust.Inline.Internal
 import Language.Rust.Inline.Marshal
 import Language.Rust.Inline.Parser
 import Language.Rust.Inline.Pretty
-import Language.Rust.Inline.Storable.TH      ( mkStorable )
+import Language.Rust.Inline.TH.Storable      ( mkStorable )
 
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Quote             ( QuasiQuoter(..) )

--- a/src/Language/Rust/Inline.hs
+++ b/src/Language/Rust/Inline.hs
@@ -64,6 +64,7 @@ module Language.Rust.Inline (
   withByteString,
   unsafeLocalState,
   mkStorable,
+  mkReprC,
 
   -- * Top-level Rust items
   externCrate,
@@ -75,6 +76,7 @@ import Language.Rust.Inline.Marshal
 import Language.Rust.Inline.Parser
 import Language.Rust.Inline.Pretty
 import Language.Rust.Inline.TH.Storable      ( mkStorable )
+import Language.Rust.Inline.TH.ReprC         ( mkReprC )
 
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Quote             ( QuasiQuoter(..) )

--- a/src/Language/Rust/Inline.hs
+++ b/src/Language/Rust/Inline.hs
@@ -46,9 +46,12 @@ module Language.Rust.Inline (
   mkContext,
   lookupRTypeInContext,
   getRTypeInContext,
+  lookupHTypeInContext,
+  getHTypeInContext,
   -- ** Built-in contexts
   basic,
   libc,
+  ghcUnboxed,
   functions,
   pointers,
   -- ** Marshalling

--- a/src/Language/Rust/Inline.hs
+++ b/src/Language/Rust/Inline.hs
@@ -338,11 +338,11 @@ processQQ safety isPure (QQParse rustRet rustBody rustNamedArgs) = do
   let (retArg, retTy, ret)
          | retByVal  = ( []
                        , renderType rustRet'
-                       , "out.into()"
+                       , "out.marshal()"
                        )
          | otherwise = ( ["ret_" ++ qqStrName ++ ": *mut " ++ renderType rustRet']
                        , "()"
-                       , "unsafe { std::ptr::write(ret_" ++ qqStrName ++ ", out.into()) }"
+                       , "unsafe { std::ptr::write(ret_" ++ qqStrName ++ ", out.marshal()) }"
                        )
   void . emitCodeBlock . unlines $
     [ "#[no_mangle]"
@@ -352,7 +352,7 @@ processQQ safety isPure (QQParse rustRet rustBody rustNamedArgs) = do
                         , let marshal x = if v then x else "*const " ++ x
                         ] ++ retArg)
     , ") -> " ++ retTy ++ " {"
-    , unlines [ "  let " ++ s ++ ": " ++ renderType t ++ " = " ++ marshal s ++ ".into();"
+    , unlines [ "  let " ++ s ++ ": " ++ renderType t ++ " = " ++ marshal s ++ ".marshal();"
               | (s,t,v) <- zip3 rustArgNames rustConvertedArgs argsByVal
               , let marshal x = if v then x else "unsafe { std::ptr::read(" ++ x ++ ") }"
               ]

--- a/src/Language/Rust/Inline/Context.hs
+++ b/src/Language/Rust/Inline/Context.hs
@@ -163,8 +163,7 @@ libc = mkContext
 -- memory layouts.
 basic :: Q Context
 basic = mkContext
-  [ ([ty| bool  |], [t| Word8   |])
-  , ([ty| char  |], [t| Char    |]) -- 4 bytes
+  [ ([ty| char  |], [t| Char    |]) -- 4 bytes
   , ([ty| i8    |], [t| Int8    |])
   , ([ty| i16   |], [t| Int16   |])
   , ([ty| i32   |], [t| Int32   |])
@@ -177,6 +176,7 @@ basic = mkContext
   , ([ty| f64   |], [t| Double  |])
   , ([ty| isize |], [t| Int     |])
   , ([ty| usize |], [t| Word    |])
+  , ([ty| bool  |], [t| Word8   |])
   , ([ty| ()    |], [t| ()      |])
   ]
 

--- a/src/Language/Rust/Inline/Internal.hs
+++ b/src/Language/Rust/Inline/Internal.hs
@@ -64,8 +64,12 @@ initModuleState contextMaybe = do
       -- add a hook to actually generate, compile, etc. the Rust file when we
       -- are done processing the module.
       addModFinalizer $ do
-        Just (ModuleState { codeBlocks = code, crates = deps }) <- getQ
-        let code' = unlines (reverse code)
+        Just (ModuleState { codeBlocks = code
+                          , crates = deps
+                          , getContext = Context (_,_,impls) }) <- getQ
+        
+        let marshalIntoTrait = "trait MarshalInto<T> { fn marshal(self) -> T; }"
+        let code' = unlines (marshalIntoTrait : reverse (code ++ impls))
 
         -- If there are no dependencies, run `rustc`. Else, go through `cargo`
         -- and store dependencies in `.inline-rust-quasi` folder.

--- a/src/Language/Rust/Inline/Internal.hs
+++ b/src/Language/Rust/Inline/Internal.hs
@@ -17,6 +17,10 @@ module Language.Rust.Inline.Internal (
   getHType,
   addForeignRustFile,
   addForeignRustFile',
+  getContext,
+  peekContext,
+  extendContext,
+  initModuleState,
 ) where
 
 import Language.Rust.Inline.Context
@@ -102,6 +106,21 @@ setContext context = do
     Nothing -> void (initModuleState (Just context))
     Just _ -> reportError "The module has already been initialised (setContext)"
   pure []
+
+extendContext :: Q Context -> Q [Dec]
+extendContext qExtension = do
+  extension <- qExtension
+  moduleState <- initModuleState Nothing
+  putQ (moduleState { getContext = extension <> getContext moduleState })
+  pure []
+  
+
+peekContext :: Q Context
+peekContext = do
+  moduleState :: Maybe ModuleState <- getQ
+  case moduleState of
+    Nothing -> mempty 
+    Just ms -> pure (getContext ms)
 
 
 -- | Search in a 'Context' for the Haskell type corresponding to a Rust type.

--- a/src/Language/Rust/Inline/Marshal.hs
+++ b/src/Language/Rust/Inline/Marshal.hs
@@ -52,7 +52,7 @@ ghcMarshallable ty = do
             , [t| Int    |], [t| Int#    |]
             , [t| Word   |], [t| Word#   |]
             , [t| Double |], [t| Double# |]
-            , [t| Float |],  [t| Float#  |]
+            , [t| Float  |], [t| Float#  |]
             
             , [t| Bool |], [t| () |]
             
@@ -60,7 +60,6 @@ ghcMarshallable ty = do
             , [t| Word8 |], [t| Word16 |], [t| Word32 |], [t| Word64 |]
            
             , [t| Addr# |]
-            , [t| MutableByteArray# |]
          --   , [t| ForeignObj# |] TODO: where is this even defined
             , [t| ByteArray# |]
             ]
@@ -68,11 +67,8 @@ ghcMarshallable ty = do
             , [t| FunPtr |]
             , [t| StablePtr |]
             , [t| StablePtr# |]
+            , [t| MutableByteArray# |]
             ]
-
-
-
-
 
 
 -- * Function pointers

--- a/src/Language/Rust/Inline/Parser.hs
+++ b/src/Language/Rust/Inline/Parser.hs
@@ -127,7 +127,7 @@ parseQQ input = do
 
 -- | Utility function for parsing AST structures from listf of spanned tokens
 parseFromToks :: Parse a => [SpTok] -> Either ParseFail a
-parseFromToks toks = execParserTokens parser (reverse toks) initPos
+parseFromToks toks = execParserTokens parser toks initPos
 
 -- | Identifies an open brace token
 openBrace :: SpTok -> Bool

--- a/src/Language/Rust/Inline/Pretty.hs
+++ b/src/Language/Rust/Inline/Pretty.hs
@@ -10,12 +10,13 @@ Portability : GHC
 
 module Language.Rust.Inline.Pretty (
   renderType,
+  renderItem,
   renderTokens,
 ) where
 
 import Language.Rust.Pretty                    ( Pretty(..) )
 import Language.Rust.Data.Position             ( Spanned(..) )
-import Language.Rust.Syntax                    ( Ty, Token(..), TokenTree(..), TokenStream(..) )
+import Language.Rust.Syntax                    ( Ty, Token(..), TokenTree(..), TokenStream(..), Item )
 
 import Data.Text.Prettyprint.Doc               ( layoutPretty, defaultLayoutOptions )
 import Data.Text.Prettyprint.Doc.Render.String ( renderString )
@@ -27,6 +28,10 @@ render = renderString . layoutPretty defaultLayoutOptions . prettyUnresolved
 -- | Render a Rust type into a 'String'.
 renderType :: Ty a -> String
 renderType = render
+
+-- | Render a Rust item into a 'String'.
+renderItem :: Item a -> String
+renderItem = render
 
 -- | Render a sequence of Rust 'Token's into a 'String'.
 renderTokens :: [Spanned Token] -> String

--- a/src/Language/Rust/Inline/TH.hs
+++ b/src/Language/Rust/Inline/TH.hs
@@ -1,0 +1,108 @@
+
+module Language.Rust.Inline.TH ( adtCtx, rustTyCtx, mkStorable ) where
+
+import Language.Rust.Inline.TH.Utilities  ( getTyConOpt, getTyCon )
+import Language.Rust.Inline.TH.ReprC
+import Language.Rust.Inline.TH.Storable ( mkStorable )
+import Language.Rust.Inline.Context
+import Language.Rust.Inline.Internal
+
+import Data.Text.Prettyprint.Doc ( vsep, punctuate, line', layoutPretty, defaultLayoutOptions )
+import Data.Text.Prettyprint.Doc.Render.String ( renderString )
+
+import Language.Haskell.TH ( Name, Q, TypeQ, Type(ForallT) )
+import Language.Haskell.TH.Syntax ( addTopDecls )
+import Language.Haskell.TH.Lib ( appT, conT )
+import Language.Rust.Data.Ident ( Ident ) 
+import Language.Rust.Syntax ( Ty(PathTy), Path(..), PathSegment(..), PathParameters(..) )
+import Language.Rust.Pretty ( pretty' )
+
+import Data.Maybe  ( isJust, fromMaybe )
+import Data.Monoid ( First, Any(..) )
+
+adtCtx :: Name         -- ^ name of the 'Storable' Haskell type 
+       -> Ident        -- ^ name of the Rust type
+       -> Maybe Ident  -- ^ name of the intermediate Rust type (if there is one)
+       -> Int          -- ^ how many generic parameters
+       -> Q Context
+adtCtx hADT rEnum rReprCOpt n = pure (Context ([ goRType ], [ goHType ]))
+  where
+  goRType :: RType -> Context -> First (Q HType, Maybe (Q RType))
+  goRType rTy ctx = do
+    PathTy Nothing (Path False [ PathSegment rName params _ ] _) _ <- pure rTy
+    rGen <-
+      case params of
+        Nothing -> pure []
+        Just (AngleBracketed [] tys [] _) -> pure tys
+        _ -> fail "Invalid params"
+
+    -- Filter out incorrect path types
+    () <- if rName == rEnum   then pure () else fail "Wrong name"
+    () <- if length rGen == n then pure () else fail "Wrong number of generics"
+
+    -- Look up generic args recursively
+    (hGen, rInterGenOpt) <- fmap unzip $ traverse (`lookupRTypeInContext` ctx) rGen
+
+    -- Compute the intermediate #[repr(C)] rust type (if we even need one)
+    let needInter = getAny $ foldMap Any (isJust rReprCOpt : map isJust rInterGenOpt)
+    let rInter :: Maybe (Q RType)
+        rInter = if needInter
+                   then let rReprC = fromMaybe rEnum rReprCOpt
+                            rInterGen = zipWith (\x m -> maybe (pure x) id m) rGen rInterGenOpt
+                        in Just (mkGenPathTy rReprC <$> sequence rInterGen)
+                   else Nothing
+    
+    -- Compute the Haskell type
+    let hTy = foldl appT (conT hADT) hGen
+
+    pure (hTy, rInter)
+    
+
+  goHType :: HType -> Context -> First (Q RType)
+  goHType hTy ctx = do
+    Just (hName, hArgs) <- pure (getTyConOpt hTy)
+
+    -- Filter out incorrect type constructors
+    () <- if hName == hADT     then pure () else fail "Wrong name"
+    () <- if length hArgs == n then pure () else fail "Wrong number of parameters"
+   
+    -- Look up parameters recursively
+    rGen <- traverse (`lookupHTypeInContext` ctx) hArgs
+
+    -- Compute the Rust type
+    pure (mkGenPathTy rEnum <$> sequence rGen)
+
+-- | TODO: be flexible around naming of the generated type
+rustTyCtx :: TypeQ      -- ^ a Haskell type representing the desired Rust type
+          -> Q Context  -- ^ the context for passing from the argument Haskell type into the
+                        -- generated Rust one (and back)
+rustTyCtx tyq = do
+
+  ty' <- tyq
+  
+  -- TODO: this work is done again in mkReprC - do it only once and here
+  -- Extract the context
+  (_, ty) <-
+    case ty' of
+      ForallT tyvars [] t -> pure (tyvars, t)
+      ForallT _      _  _ -> fail "mkReprC: type cannot have context"
+      t                   -> pure ([], t)
+
+  -- Get the type and its name
+  (hADT, args) <- getTyCon ty
+
+  -- Get the current context
+  ctx <- peekContext 
+
+  -- Generate and emit the Rust types
+  (rEnum, rReprCOpt, items) <- mkReprC ctx ty'
+  let doc = vsep . punctuate line' . map pretty' $ items
+  let itemsStr = renderString . layoutPretty defaultLayoutOptions $ doc
+  decs <- emitCodeBlock itemsStr
+  addTopDecls decs
+
+  -- Produce the context
+  adtCtx hADT rEnum rReprCOpt (length args)
+  
+
+

--- a/src/Language/Rust/Inline/TH/ReprC.hs
+++ b/src/Language/Rust/Inline/TH/ReprC.hs
@@ -1,0 +1,82 @@
+{-|
+Module      : Language.Rust.Inline.TH.ReprC
+Description : Generate #[repr(C)] Rust types
+Copyright   : (c) Alec Theriault, 2018
+License     : BSD-style
+Maintainer  : alec.theriault@gmail.com
+Stability   : experimental
+Portability : GHC
+-}
+
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wwarn #-}         -- TODO: GHC bug around "unused pattern binds" in splices
+                                   -- TODO: GHC bug around setting extensions from within TH
+module Language.Rust.Inline.TH.ReprC where
+
+import Language.Rust.Inline.TH.Utilities
+import Language.Rust.Inline.Context
+
+import Language.Haskell.TH
+import Language.Rust.Syntax
+
+mkPathTy :: Ident -> Ty ()
+mkPathTy i = PathTy Nothing (Path False [ PathSegment i Nothing () ] ()) ()
+
+mkReprC :: TypeQ               -- ^ a Haskell type
+        -> (Type -> RType)
+        -> Q Context           -- ^ the declarations needed for a compatible Rust type
+mkReprC tyq func = do
+  (n, cons) <- getConstructors =<< tyq
+  
+
+  case cons of
+    [(_, tys)] -> do
+      (i, item) <- mkStruct n tys
+      pure (i, [item])
+    _ -> do
+      (is, items) <- unzip <$> traverse (curry mkStruct) cons
+      (i, item) <- mkUnion n is
+      pure (i, item : items)
+      
+
+  let rustTy = mkPathTy rustN
+
+
+  pure $ Context [ \rty _ -> if rustTy /= rty then mempty else pure tyq ]
+  
+  -- Rust stuff...
+  case cons of
+    [con] -> 
+    _ ->
+
+  where
+    noGen :: Generics ()
+    noGen = Generics [] [] (WhereClause [] ()) ()
+     
+    mkVariant :: Context -> [Type] -> Q (VariantData ())
+    mkVariant ctx tys = do
+      rustTys <- traverse func tys
+      let structFlds = [ StructField Nothing PublicV t [] () | t <- rustTys ]
+      pure (TupleD structFlds ())
+       
+
+    mkStruct :: Name -> [Type] -> Q (Ident, Item)
+    mkStruct n tys = do
+      var <- mkVariant n tys
+
+      let rustN = fromString (nameBase n)
+          struct = StructItem [] PublicV itemN var noGen ()
+
+      pure (rustN, struct)
+
+    mkUnion :: Name -> [Ident] -> Q (Ident, Item)
+    mkUnion n variantNames = do
+      let rustN = fromString (nameBase n)
+          vars = [ TupleD [StructField Nothing PublicV (mkPathTy i) [] () ] ()
+                 | i <- variantNames
+                 ]
+    
+      pure (rustN, Union [] PublicV rustN _ noGen vars ())
+      

--- a/src/Language/Rust/Inline/TH/ReprC.hs
+++ b/src/Language/Rust/Inline/TH/ReprC.hs
@@ -11,7 +11,8 @@ Portability : GHC
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Rust.Inline.TH.ReprC (
-  mkReprC
+  mkReprC,
+  mkGenPathTy,
 ) where
 
 import Language.Rust.Inline.TH.Utilities
@@ -19,12 +20,12 @@ import Language.Rust.Inline.Context
 
 import Language.Haskell.TH hiding (Stmt, Match, WildP, Unsafe, LitP, Pat)
 import Language.Rust.Syntax
-import Language.Rust.Data.Ident ( Ident, mkIdent )
+import Language.Rust.Data.Ident            ( Ident, mkIdent )
 import qualified Language.Rust.Quote as R
 
-import Control.Monad    ( void )
-import Data.Traversable ( for )
-import Data.List.NonEmpty ( NonEmpty(..) )
+import Control.Monad                       ( void )
+import Data.Traversable                    ( for )
+import Data.List.NonEmpty                  ( NonEmpty(..) )
 
 -- | TODO mangle me
 freshIdent :: String -> Q Ident
@@ -302,7 +303,7 @@ mkEnum ctx dict n cons = do
       varData <- mkVariant ctx flds
       pure (varN, Variant varN [] varData Nothing ())
 
-  let enum = Enum [] PublicV itemN vars (mkGenerics ps) ()
+  let enum = Enum [deriveCopyClone] PublicV itemN vars (mkGenerics ps) ()
 
   pure (outTy, itemN, varNs, enum)
 

--- a/src/Language/Rust/Inline/TH/ReprC.hs
+++ b/src/Language/Rust/Inline/TH/ReprC.hs
@@ -8,9 +8,6 @@ Stability   : experimental
 Portability : GHC
 -}
 
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -Wwarn #-}         -- TODO: GHC bug around "unused pattern binds" in splices
                                    -- TODO: GHC bug around setting extensions from within TH
 module Language.Rust.Inline.TH.ReprC where
@@ -20,63 +17,243 @@ import Language.Rust.Inline.Context
 
 import Language.Haskell.TH
 import Language.Rust.Syntax
+import Language.Rust.Data.Ident ( Ident, mkIdent )
 
+import Data.Traversable ( for )
+
+-- | TODO mangle me
+freshIdent :: String -> Q Ident
+freshIdent str = pure (mkIdent str)
+
+-- | The @#[derive(Copy,Clone)]@ attributes
+deriveCopyClone :: Attribute ()
+deriveCopyClone = undefined
+
+-- | The @#[repr(C)]@ attribute
+reprC :: Attribute ()
+reprC = undefined
+
+-- | Make a generic path from an idenitifer
+mkGenPath :: Ident -> [Ty ()] -> Path ()
+mkGenPath i g = Path False [ PathSegment i (Just (AngleBracketed [] g [] ())) () ] ()
+
+-- | Make a path from a single identifier.
+mkPath :: Ident -> Path ()
+mkPath i = Path False [ PathSegment i Nothing () ] ()
+
+-- | Make a path type (e.g. something like @SomeStruct@).
 mkPathTy :: Ident -> Ty ()
-mkPathTy i = PathTy Nothing (Path False [ PathSegment i Nothing () ] ()) ()
+mkPathTy i = PathTy Nothing (mkPath i) ()
 
-mkReprC :: TypeQ               -- ^ a Haskell type
-        -> (Type -> RType)
-        -> Q Context           -- ^ the declarations needed for a compatible Rust type
-mkReprC tyq func = do
-  (n, cons) <- getConstructors =<< tyq
+-- | Make a generic path type (e.g. something like @Vec<T>@).
+mkGenPathTy :: Ident -> [Ty ()] -> Ty ()
+mkGenPathTy i g = PathTy Nothing (mkGenPath i g) ()
+
+-- | Make a new type parameter.
+mkTyParam :: Ident -> TyParam ()
+mkTyParam i = TyParam [] i [] Nothing ()
+
+-- | Add a type parameter bound on an existing type parameter.
+consBound :: TyParamBound () -> TyParam () -> TyParam ()
+consBound bd (TyParam as i bds def x) = TyParam as i (bd : bds) def x
+
+-- | The @Copy@ type parameter bound.
+copyBound :: TyParamBound ()
+copyBound = TraitTyParamBound (PolyTraitRef [] (TraitRef (mkPath (mkIdent "Copy"))) ()) None ()
+
+-- | Make simple generics from a list of type parameters.
+mkGenerics :: [TyParam ()] -> Generics ()
+mkGenerics ps = Generics [] ps (WhereClause [] ()) ()
+
+type TyVarDict = [(Name, TyParam ())]
+
+
+mkReprC :: Context     -- ^ current context (in order to lookup what Rust types corresponding to
+                       -- Haskell ones)
+        -> Type        -- ^ Haskell type to convert
+        -> Q ()          -- TODO
+mkReprC ctx ty = do
   
+  -- Extract the context
+  (tyvars, ty') <-
+    case ty of
+      ForallT tyvars [] ty -> pure (tyvars, ty)
+      ForallT _      _  _  -> fail "mkReprC: type cannot have context"
+      ty                   -> pure ([], ty)
+
+  -- Synthesize the new generic args and the mapping
+  rustTyParams <- traverse (fmap mkTyParam . freshIdent . nameBase . varName) tyvars
+  let dict :: TyVarDict
+      dict = zip (map varName tyvars) rustTyParams
+
+  ctx' <- extendCtx dict ctx
+
+  -- Get the type constructors name
+  (n, cons) <- getConstructors ty'
 
   case cons of
     [(_, tys)] -> do
-      (i, item) <- mkStruct n tys
-      pure (i, [item])
+      (ty, i, item) <- mkStruct ctx' dict False n tys
+   
+      error "incomplete"
     _ -> do
-      (is, items) <- unzip <$> traverse (curry mkStruct) cons
-      (i, item) <- mkUnion n is
-      pure (i, item : items)
-      
-
-  let rustTy = mkPathTy rustN
-
-
-  pure $ Context [ \rty _ -> if rustTy /= rty then mempty else pure tyq ]
-  
-  -- Rust stuff...
-  case cons of
-    [con] -> 
-    _ ->
-
-  where
-    noGen :: Generics ()
-    noGen = Generics [] [] (WhereClause [] ()) ()
+      (tys, is,     items) <- unzip3 <$> traverse (uncurry (mkStruct ctx' dict True)) cons
+      (tyU, iUnion, itemU) <- mkUnion dict (mkName (nameBase n ++ "CUnion")) tys
+      (tyE, iTagged, item) <- mkTagged ctx' dict (mkName (nameBase n ++ "C")) (mkPathTy (mkIdent "u8")) tyU
      
-    mkVariant :: Context -> [Type] -> Q (VariantData ())
-    mkVariant ctx tys = do
-      rustTys <- traverse func tys
-      let structFlds = [ StructField Nothing PublicV t [] () | t <- rustTys ]
-      pure (TupleD structFlds ())
-       
+      (tyE, iEnum, iVars, itemE) <- mkEnum ctx' dict n cons
+      error "unimplemented" -- TODO two 'Into' symmetric impls
 
-    mkStruct :: Name -> [Type] -> Q (Ident, Item)
-    mkStruct n tys = do
-      var <- mkVariant n tys
 
-      let rustN = fromString (nameBase n)
-          struct = StructItem [] PublicV itemN var noGen ()
 
-      pure (rustN, struct)
+-- | Extend the context with the type variables in the given dictionary.
+extendCtx :: TyVarDict -> Context -> Q Context
+extendCtx dict ctx = dictCtx <> pure ctx
+  where
+    dictCtx = mkContext [ (mkPathTy i, varT v)
+                        | (v, TyParam _ i _ _ _) <- dict
+                        ]
 
-    mkUnion :: Name -> [Ident] -> Q (Ident, Item)
-    mkUnion n variantNames = do
-      let rustN = fromString (nameBase n)
-          vars = [ TupleD [StructField Nothing PublicV (mkPathTy i) [] () ] ()
-                 | i <- variantNames
-                 ]
-    
-      pure (rustN, Union [] PublicV rustN _ noGen vars ())
-      
+
+-- | Make an enum corresponding to an ADT. For example:
+--
+-- @
+-- enum EitherInt<T> {
+--   LeftInt(i32),
+--   Right(T),
+-- }
+-- @
+--
+mkEnum :: Context           -- ^ current context (in order to lookup what Rust types corresponding to
+                            -- Haskell ones)
+       -> TyVarDict         -- ^ Mapping of Haskell type variables to Rust type parameters
+       -> Name              -- ^ What name to give the union
+       -> [(Name, [Type])]  -- ^ Variants
+       -> Q ( Ty ()         --   Output type
+            , Ident         --   Output name
+            , [Ident]       --   Variant names
+            , Item ()       --   Union definition
+            )
+mkEnum ctx dict n cons = do
+  let itemN = mkIdent (nameBase n)
+      ps = [ typ  | (ht, typ) <- dict ]
+      outTy = mkGenPathTy itemN [ mkPathTy i | TyParam _ i _ _ _ <- ps ]
+  
+  (varNs, vars) <- fmap unzip $
+    for cons $ \(n, flds) -> do
+      let varN = mkIdent (nameBase n)
+      varData <- mkVariant ctx flds
+      pure (varN, Variant varN [] varData Nothing ())
+
+  let enum = Enum [] PublicV itemN vars (mkGenerics ps) ()
+
+  pure (outTy, itemN, varNs, enum)
+
+
+-- | Make a union struct. It is assumed all of the parameters in the dictionary are used. For
+-- instance, given the variants @SomeStruct<a>@ and @AnotherStruct@, the following would be
+-- generated:
+--
+-- @
+-- #[repr(C)]
+-- #[derive(Copy,Clone)]
+-- union SomeUnion<a: Copy> {
+--   v0: SomeStruct<a>,
+--   v1: AnotherStruct,
+-- }
+-- @
+--
+mkUnion :: TyVarDict   -- ^ Mapping of Haskell type variables to Rust type parameters
+        -> Name        -- ^ What name to give the union
+        -> [Ty ()]     -- ^ Variants
+        -> Q ( Ty ()   --   Output type
+             , Ident   --   Output name
+             , Item () --   Union definition
+             )
+mkUnion dict n tys = do
+  let itemN = mkIdent (nameBase n)
+      copyPs = [ consBound copyBound typ  | (ht, typ) <- dict ]
+      fields = [ StructField (Just fld) PublicV ty [] () 
+               | (ty, i) <- zip tys [0..]
+               , let fld = mkIdent ("v" ++ show i)
+               ]
+      var = StructD fields ()
+      union = Union [reprC, deriveCopyClone] PublicV itemN var (mkGenerics copyPs) ()
+      outTy = mkGenPathTy itemN [ mkPathTy i | TyParam _ i _ _ _ <- copyPs ]
+
+  pure (outTy, itemN, union)
+
+
+-- | Make a tagged (esp. union) compound data. For example:
+--
+-- @
+-- #[repr(C)]
+-- #[derive(Copy,Clone)]
+-- struct TaggedADT<a: Copy> {
+--   tag: u8,
+--   payload: UnionADT<a>,
+-- }
+-- @
+mkTagged :: Context     -- ^ current context (in order to lookup what Rust types corresponding to
+                        -- Haskell ones)
+         -> TyVarDict   -- ^ Mapping of Haskell type variables to Rust type parameters
+         -> Name        -- ^ What name to give the struct
+         -> Ty ()       -- ^ Discriminator type
+         -> Ty ()       -- ^ Payload union type
+         -> Q ( Ty ()   --   Output type
+              , Ident   --   Output name
+              , Item () --   Struct deifnition
+              )
+mkTagged ctx dict n disc union = do
+  let itemN = mkIdent (nameBase n)
+      copyPs = [ consBound copyBound typ | (ht, typ) <- dict ]
+      fields = [ StructField (Just (mkIdent "tag")) PublicV disc [] ()
+               , StructField (Just (mkIdent "payload")) PublicV union [] ()
+               ]
+      var = StructD fields ()
+      struct = StructItem [reprC, deriveCopyClone] PublicV itemN var (mkGenerics copyPs) ()
+      outTy = mkGenPathTy itemN [ mkPathTy i | TyParam _ i _ _ _ <- copyPs ]
+
+  pure (outTy, itemN, struct)
+
+
+-- | Make a tuple struct from a given set of fields. For instance, given the fields @[Int, a]@,
+-- the following would be generated:
+--
+-- @
+-- #[repr(C)]
+-- #[derive(Copy,Clone)]
+-- struct SomeStruct<a: Copy>(i32, a);
+-- @
+--
+mkStruct :: Context     -- ^ current context (in order to lookup what Rust types corresponding to
+                        -- Haskell ones)
+         -> TyVarDict   -- ^ Mapping of Haskell type variables to Rust type parameters
+         -> Bool        -- ^ Enforce a 'Copy' constraint on type parameters
+         -> Name        -- ^ What name to give the struct
+         -> [Type]      -- ^ Fields of the struct
+         -> Q ( Ty ()   --   Output type
+              , Ident   --   Output name
+              , Item () --   Struct definition
+              )
+mkStruct ctx dict copy n tys = do
+  var <- mkVariant ctx tys
+
+  let itemN = mkIdent (nameBase n)
+      haskTysUsed = concatMap getAllVars tys
+      copyPs = [ if copy then consBound copyBound typ else typ
+               | (ht, typ) <- dict, ht `elem` haskTysUsed
+               ]
+      struct = StructItem [reprC, deriveCopyClone] PublicV itemN var (mkGenerics copyPs) ()
+      outTy = mkGenPathTy itemN [ mkPathTy i | TyParam _ i _ _ _ <- copyPs ]
+
+
+  pure (outTy, itemN, struct)
+
+-- | Construct the variant data for struct fields.
+mkVariant :: Context -> [Type] -> Q (VariantData ())
+mkVariant _ [] = pure (UnitD ())
+mkVariant ctx tys = do
+  rustTys <- traverse (`getHTypeInContext` ctx) tys
+  let structFlds = [ StructField Nothing PublicV t [] () | t <- rustTys ]
+  pure (TupleD structFlds ())

--- a/src/Language/Rust/Inline/TH/Storable.hs
+++ b/src/Language/Rust/Inline/TH/Storable.hs
@@ -195,9 +195,8 @@ processField ty = do
                  })
 
   -- TODO: consider degenerate sizeof(..) = 0 cases
-  let offset = unType <$> [|| $$beginOff `div` $$sizeTy ||]
-  pure ( \addrE -> [e| peek (castPtr $(pure addrE) `plusPtr` $offset) |]
-       , \addrE -> [e| poke (castPtr $(pure addrE) `plusPtr` $offset) |]
+  pure ( \addrE -> [e| peek (castPtr $(pure addrE) `plusPtr` $(unType <$> beginOff)) |]
+       , \addrE -> [e| poke (castPtr $(pure addrE) `plusPtr` $(unType <$> beginOff)) |]
        )
 
 -- | Process an algebraic data type.

--- a/src/Language/Rust/Inline/TH/Utilities.hs
+++ b/src/Language/Rust/Inline/TH/Utilities.hs
@@ -1,0 +1,83 @@
+{-|
+Module      : Language.Rust.Inline.TH.Utilities
+Description : Generate Storable instances
+Copyright   : (c) Alec Theriault, 2018
+License     : BSD-style
+Maintainer  : alec.theriault@gmail.com
+Stability   : experimental
+Portability : GHC
+-}
+
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wwarn #-}         -- TODO: GHC bug around "unused pattern binds" in splices
+                                   -- TODO: GHC bug around setting extensions from within TH
+module Language.Rust.Inline.TH.Utilities (
+  getConstructors,
+) where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax hiding (lift)
+
+import Data.Maybe                (fromMaybe)
+
+
+-- | Given a fully applied type, decompose it into a list of constructors and
+-- the type of the arguments they expect.
+--
+-- >>> getContructors =<< [t| Either Int a |]
+--
+--
+-- Supports only simple Haskell 98 style constructors.
+getConstructors :: Type -> Q (Name, [(Name, [Type])])
+getConstructors ty = do
+  -- Get the type constructors name
+  (n,args) <- getTyCon ty
+  info <- reify n
+
+  -- Get the constructors out
+  (cons, tyvars) <-
+    case info of
+      TyConI (DataD    _c _n tyvars _k cons _ds) -> pure (cons, tyvars)
+      TyConI (NewtypeD _c _n tyvars _k con  _ds) -> pure ([con], tyvars)
+      _ -> fail "mkStorable: could not find simple type constructor"
+
+  -- Get the fields
+  let dict = zip (map varName tyvars) args
+  cons' <- traverse (getSubCon dict) cons
+
+  pure (n, cons')
+
+
+-- | Get the name of a type variable binder
+varName :: TyVarBndr -> Name
+varName (PlainTV n) = n
+varName (KindedTV n _) = n
+
+-- | Apply a substitution (of type variable to type) to a type
+subTy :: [(Name, Type)] -> Type -> Type
+subTy dict (AppT t1 t2) = AppT (subTy dict t1) (subTy dict t2)
+subTy dict (VarT n) = fromMaybe (VarT n) $ lookup n dict
+subTy dict (InfixT t1 n t2) = InfixT (subTy dict t1) n (subTy dict t2)
+subTy dict (ParensT t) = ParensT (subTy dict t)
+subTy _    t = t
+
+-- | Extract the type constructor of a type, along with the type arguments
+getTyCon :: Type -> Q (Name, [Type])
+getTyCon = fmap (\(n, argsRev) -> (n, reverse argsRev)) . go
+  where
+    go (ConT n) = pure (n, [])
+    go (AppT t1 t2) = fmap (\(n, args) -> (n, t2 : args)) (go t1)
+    go (InfixT t1 n t2) = pure (n, [t1, t2])
+    go (ParensT t) = go t
+    go _ = fail "getTyCon: could not find type constructor"
+  
+-- | Extract the fields from a constructor, applying a substitution along the
+-- way
+getSubCon :: [(Name, Type)] -> Con -> Q (Name, [Type])
+getSubCon dict (NormalC c ts)   = pure (c, [ subTy dict t | (_, t) <- ts ])
+getSubCon dict (RecC c ts)      = pure (c, [ subTy dict t | (_, _, t) <- ts ])
+getSubCon dict (InfixC t1 c t2) = pure (c, [ subTy dict t | (_, t) <- [t1,t2] ])
+getSubCon _    _ = fail "processCon: unsupported constructor type"
+


### PR DESCRIPTION
Extend contexts support passing Haskell ADTs directly into Rust enums. The core insights are that 

  * `Storable` lets us reorganize what exactly gets passed through the FFI. On the Rust side, we need to make that explicit by having an intermediate `#[repr(C)]` type and some conversions to and from that type.
  * These sorts of conversion shenanigans only work when we are passing the actual values through the FFI - functions and pointers won't work for this (another face of the same observation: the `Storable` instances for `Ptr a` and `FunPtr a` do not impose superclass `Storable` constraints)

When merged, this PR will go a long way to helping on #1.

  - [x] Extend contexts to support intermediate Rust types.
  - [x] Generate `#[repr(C)]` unions/structs corresponding to the derived `Storable` instances for ADTs
  - [x] Generate enums corresponding to the ADTs
  - [x] Generate `Into`/`From` trait impls for converting between the `#[repr(C)]` union/struct form and the enum form
  - [x] Wrap all of this into a simple TH function
  - [ ] Update all of the documentation