### PR TITLE
MonadFail First orphan

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,12 @@ If you want to use this with GHCi, make sure to pass in `-fobject-code`.
 
 ## Building
 
-This currently depends on a GHC [feature][1] that will be available in GHC 8.6.
-Until then, you'll have to [build GHC][0] yourself or get a binary. For the
-latter, you can install one of GHC's nightly builds.
+This depends ghc >= 8.6. An easy way to run the examples is to use environment files:
 
-    $ curl https://ghc-artifacts.s3.amazonaws.com/nightly/validate-x86_64-darwin/latest/bindist.tar.xz | tar xz
-    $ cd ghc-*
-    $ ./configure && make install
-
-With that installed, something like the following should work
-
-    $ cabal new-build -w /usr/local/bin/ghc-8.5.20180423
-    $ cabal new-test  -w /usr/local/bin/ghc-8.5.20180423
-
-Running the examples is only a matter of threading through the right package
-databases. With a new enough Cabal, `new-exec` does this for you.
-
-    $ cabal new-exec -w /usr/local/bin/ghc-8.5.20180423 ghc -- -threaded -package inline-rust examples/Hello.hs
+    $ cabal build --write-ghc-environment-files=always
+    $ ghc -threaded examples/Hello.hs
     [1 of 1] Compiling Main             ( examples/Hello.hs, examples/Hello.o )
+    ...
     Linking examples/Hello ...
     $ ./examples/Hello
     Haskell: Hello. Enter a number:

--- a/inline-rust.cabal
+++ b/inline-rust.cabal
@@ -45,7 +45,7 @@ library
                      , ForeignFunctionInterface
                      , ScopedTypeVariables
 
-  build-depends:       base                 >=4.9 && <5.0
+  build-depends:       base                 >=4.12 && <5.0
                      , language-rust        >=0.2.0
                      , prettyprinter        >=1.1
                      , process              >=1.4

--- a/src/Language/Rust/Inline/Context.hs
+++ b/src/Language/Rust/Inline/Context.hs
@@ -7,6 +7,7 @@ Maintainer  : alec.theriault@gmail.com
 Stability   : experimental
 Portability : GHC
 -}
+{-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -35,9 +36,13 @@ import Data.Int                    ( Int8, Int16, Int32, Int64 )
 import Data.Word                   ( Word8, Word16, Word32, Word64 )
 import Foreign.Ptr                 ( Ptr, FunPtr )
 import Foreign.C.Types             -- pretty much every type here is used
+import qualified Control.Monad.Fail as Fail
 
 import GHC.Exts                    ( Char#, Int#, Word#, Float#, Double#,
                                      ByteArray# )
+
+instance Fail.MonadFail First where
+  fail _ = mempty
 
 -- Easier on the eyes
 type RType = Ty ()


### PR DESCRIPTION
Makes a horrible orphan instance for `First`, needed because of the `MonadFail` change. It's not perfect but at least people who come here to try it out will be able to run the examples.